### PR TITLE
Photometry error

### DIFF
--- a/examples/photometry_example.py
+++ b/examples/photometry_example.py
@@ -6,9 +6,15 @@ import numpy as np
 from telescope_baseline.photometry.photoclass import InstClass, ObsClass, TargetClass
 from telescope_baseline.tools.mission.parameters import Parameters
 
+#parameter setting
+par=Parameters.get_instance()
+par.set_aperture_diameter(0.36)
+par.set_quantum_efficiency(0.7)
+par.set_low_wavelength_limit(1.0e-6)
+print("Is this OK? -> telescope_through_put=", par.telescope_through_put)
+cpix=1.7
 
 inst=InstClass()
-
 target=TargetClass()
 target.teff = 3000.0*u.K #K
 target.rstar = 0.2*const.R_sun #Rsolar
@@ -19,11 +25,10 @@ obs.texposure = 0.0833*u.h #cadence [hour]
 obs.tframe = 12.5*u.s  #time for one frame [sec]
 obs.napix = 15 # number of the pixels in aperture 
 obs.mu = 1 
-S=1.8*1.8*np.pi #core size
+S=cpix*cpix*np.pi #core size
 obs.effnpix = S/3.0 #3 is an approx. increment factor of PSF
 obs.mu = 1 
 obs.target = target
-
 obs.update()
 
 print("=========================")
@@ -33,3 +38,14 @@ print("readout [ppm]=",obs.sigr)
 print("photon [ppm]=",obs.sign)
 print("=========================")
 print("photon relative=",obs.sign_relative)
+
+
+seven_sigma_percent=np.sqrt(1.0/obs.nphoton_exposure)*1e2*7.0
+roundvalue=np.round(seven_sigma_percent,2)
+print("7 sigma per exposure = ",seven_sigma_percent)
+
+criterion = 0.2 #percent  per exposure
+if roundvalue > criterion:
+    raise ValueError("Current setting is not suitable for exoplanet survey!")
+else:
+    print("We can do the exoplanet survey!")

--- a/examples/photometry_example.py
+++ b/examples/photometry_example.py
@@ -3,30 +3,18 @@ from exocounts import convmag
 from astropy import constants as const
 from astropy import units as u
 import numpy as np
-from telescope_baseline.photometry.photoobs import obsclass
+from telescope_baseline.photometry.photoclass import InstClass, ObsClass, TargetClass
+from telescope_baseline.tools.mission.parameters import Parameters
 
-ejas=exocounts.InstClass()
-ejas.lamb = 1.25*u.micron #micron
-ejas.dlam = 0.7*u.micron #micron
-#ejas.lamb = 1.3*u.micron #micron
-#ejas.dlam = 0.6*u.micron #micron
 
-ejas.dtel = 0.34*u.m #telescope diameter m
-ejas.dstel = 0.14*u.m #secondary telescope diameter m or 12.4 (3 tels)
+inst=InstClass()
 
-QE=0.7
-ejas.throughput = QE*0.85*0.95
-ejas.ndark = 15.5/u.s #dark current
-ejas.nread = 15.0 #nr
-ejas.fullwell = 150000.
-
-target=exocounts.TargetClass()
+target=TargetClass()
 target.teff = 3000.0*u.K #K
 target.rstar = 0.2*const.R_sun #Rsolar
-target.d = 15.0*u.pc #pc
+target.d=16.0*u.pc 
 
-obs=obsclass(ejas,target) 
-
+obs=ObsClass(inst,target) 
 obs.texposure = 0.0833*u.h #cadence [hour]
 obs.tframe = 12.5*u.s  #time for one frame [sec]
 obs.napix = 15 # number of the pixels in aperture 
@@ -34,9 +22,8 @@ obs.mu = 1
 S=1.8*1.8*np.pi #core size
 obs.effnpix = S/3.0 #3 is an approx. increment factor of PSF
 obs.mu = 1 
-
-target.d=16.0*u.pc #change targets
 obs.target = target
+
 obs.update()
 
 print("=========================")

--- a/examples/photometry_example.py
+++ b/examples/photometry_example.py
@@ -3,6 +3,7 @@ from exocounts import convmag
 from astropy import constants as const
 from astropy import units as u
 import numpy as np
+from telescope_baseline.photometry.photoobs import obsclass
 
 ejas=exocounts.InstClass()
 ejas.lamb = 1.25*u.micron #micron
@@ -24,7 +25,7 @@ target.teff = 3000.0*u.K #K
 target.rstar = 0.2*const.R_sun #Rsolar
 target.d = 15.0*u.pc #pc
 
-obs=exocounts.ObsClass(ejas,target) 
+obs=obsclass(ejas,target) 
 
 obs.texposure = 0.0833*u.h #cadence [hour]
 obs.tframe = 12.5*u.s  #time for one frame [sec]

--- a/src/telescope_baseline/photometry/photoclass.py
+++ b/src/telescope_baseline/photometry/photoclass.py
@@ -6,7 +6,7 @@ class InstClass(object):
     """Class for Instrumental Setting used in exocounts, matched to InstClass in exocounts but using Parameters."""
     def __init__(self):
         
-        par = Parameters()
+        par = Parameters.get_instance()    
         self.lamb = (par.high_wavelength_limit + par.low_wavelength_limit)/2.0*u.m
         self.dlam = (par.high_wavelength_limit - par.low_wavelength_limit)*u.m
         self.dtel = par.aperture_diameter*u.m

--- a/src/telescope_baseline/photometry/photoclass.py
+++ b/src/telescope_baseline/photometry/photoclass.py
@@ -1,13 +1,42 @@
 import numpy as np
 from astropy import units as u
+from telescope_baseline.tools.mission.parameters import Parameters
 
-class obsclass(object):
+class InstClass(object):
+    """Class for Instrumental Setting used in exocounts, matched to InstClass in exocounts but using Parameters."""
+    def __init__(self):
+        
+        par = Parameters()
+        self.lamb = (par.high_wavelength_limit + par.low_wavelength_limit)/2.0*u.m
+        self.dlam = (par.high_wavelength_limit - par.low_wavelength_limit)*u.m
+        self.dtel = par.aperture_diameter*u.m
+        self.dstel = par.aperture_inner_diameter*u.m
+        self.throughput = par.total_efficiency
+        self.ndark = par.dark_current/u.s  # nd
+        self.nread = par.read_out_noise  # nr
+        self.fullwell = par.full_well_electron
+        self.fgtel = 0.0  # foreground from a telescope
+        self.fgatm = 0.0  # foreground from atmosphere
+
+
+class TargetClass(object):
+    """Class for Astronomical Targets."""
+
+    def __init__(self):
+        self.teff = None
+        self.rstar = None
+        self.d = None
+        self.name = 'No Name'
+        self.contrast = 1
+        
+class ObsClass(object):
     """Class for Observational Procedure."""
 
     def __init__(self, Inst, Target):
+
         self.inst = Inst
         self.target = Target
-
+        
         # INPUTS
         self.mu = None
         self.texposure = None  # th
@@ -48,8 +77,6 @@ class obsclass(object):
         from exocounts import nstar
         nstar.Nstar(self.inst, self.target, self)
         ppm = 1.e6
-        # hr2sec=3600.0
-        # ndframe=self.texposure*hr2sec*self.inst.ndark
         ndframe = self.texposure.to(u.s)*self.inst.ndark
 
         try:
@@ -73,3 +100,5 @@ class obsclass(object):
                                        self.texposure*(self.inst.dtel/2.0)**2*np.pi*self.inst.throughput).to(1)
         except:
             self.nphoton_foreground = None
+
+

--- a/src/telescope_baseline/photometry/photoobs.py
+++ b/src/telescope_baseline/photometry/photoobs.py
@@ -1,0 +1,75 @@
+import numpy as np
+from astropy import units as u
+
+class obsclass(object):
+    """Class for Observational Procedure."""
+
+    def __init__(self, Inst, Target):
+        self.inst = Inst
+        self.target = Target
+
+        # INPUTS
+        self.mu = None
+        self.texposure = None  # th
+        self.tframe = None  # tr
+        self.napix = None
+        self.effnpix = None  # conversion for the brightest pixel
+        self.fgaperture = None  # for foreground noise
+        ####OUTPUTS####
+        self.nphoton_exposure = None
+        self.nphoton_frame = None
+        self.flux = None
+        self.photonf = None
+
+        self.sign = None
+        self.sigd = None
+        self.sigr = None
+        self.sign_relative = None
+        self.sigd_relative = None
+        self.sigr_relative = None
+
+        self.sat = False  # Saturation
+
+    def update(self):
+        """Update status."""
+        self.calc_noise()
+
+        try:
+            self.nphoton_brightest = self.nphoton_frame/self.effnpix
+            if self.nphoton_brightest > self.inst.fullwell:
+                self.sat = True
+            else:
+                self.sat = False
+        except:
+            self.sat = False
+
+    def calc_noise(self):
+        """compute noises."""
+        from exocounts import nstar
+        nstar.Nstar(self.inst, self.target, self)
+        ppm = 1.e6
+        # hr2sec=3600.0
+        # ndframe=self.texposure*hr2sec*self.inst.ndark
+        ndframe = self.texposure.to(u.s)*self.inst.ndark
+
+        try:
+            self.sigd = np.sqrt(self.mu*self.napix*ndframe)
+            self.sigd_relative = self.sigd/self.nphoton_exposure*ppm
+        except:
+            self.sigd = None
+            self.sigd_relative = None
+
+        try:
+            self.sigr = np.sqrt(
+                self.mu*self.napix*self.texposure.to(u.s)/self.tframe)*self.inst.nread
+            self.sigr_relative = self.sigr/self.nphoton_exposure*ppm
+        except:
+            self.sigr = None
+            self.sigr_relative = None
+
+        # foreground
+        try:
+            self.nphoton_foreground = (self.fgaparture*(self.inst.fgtel+self.inst.fgatm)*self.inst.dlam *
+                                       self.texposure*(self.inst.dtel/2.0)**2*np.pi*self.inst.throughput).to(1)
+        except:
+            self.nphoton_foreground = None


### PR DESCRIPTION
Parameters()を使用してexoplanetsの条件をみたすかどうかのコードをPRします。
といっても実態は[exocounts](https://github.com/HajimeKawahara/exocounts)を使っているので、主要なコードはexocountsに必要な値をParameters()からとってきて代入するだけです。[photometry_error.py](https://github.com/JASMINE-Mission/telescope_baseline/blob/photometry_error/examples/photometry_example.py)が確認コードです

`python examples/photometry_error.py`

で判定します。

いくつか気になる点が、、、
- 現在のParameters()では`par.telescope_through_put`が固定値で変更できませんが、今の値は結構高めだと思います。
- 可能ならParameters()の中に`cpix`を計算する関数を実装していただけないでしょうか？(別PRで)　@yamadayy 
よろしくおねがいいたします