### PR TITLE
drop trailing white spaces in dataclass/efficiency.py

### DIFF
--- a/src/telescope_baseline/dataclass/efficiency.py
+++ b/src/telescope_baseline/dataclass/efficiency.py
@@ -54,7 +54,7 @@ class Efficiency:
         """evaluate the efficiency by a linear interpolation.
 
         Args:
-            wavelength: wavelength 
+            wavelength: wavelength
 
         Returns:
             interpolated efficiency
@@ -74,7 +74,7 @@ class Efficiency:
         """compute the weighted mean of interpolated efficiency.
 
         Args:
-            wavelength: wavelength 
+            wavelength: wavelength
             weight: weight
 
         Returns:


### PR DESCRIPTION
`dataclass/effciency.py` is revised to follow the pep8 style.
The code contained the following violation:

- Trailing whitespace
