### PR TITLE
change codeclimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,11 @@
 version: "2"
 checks:
+  file-lines:
+    config:
+      threshold: 270  # default 250
   method-count:
     config:
-      threshold: 30
+      threshold: 30  # default 20.
 plugins:
   sonar-python:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,10 @@ checks:
       threshold: 270  # default 250
   method-count:
     config:
-      threshold: 30  # default 20.
+      threshold: 30  # default 20
+  method-lines:
+    config:
+      threshold: 40  # default 25
 plugins:
   sonar-python:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,17 +1,10 @@
 version: "2"
-checks:
-  file-lines:
-    config:
-      threshold: 270  # default 250
-  method-count:
-    config:
-      threshold: 30  # default 20
-  method-lines:
-    config:
-      threshold: 40  # default 25
 plugins:
   sonar-python:
     enabled: true
+    checks:
+      python:S107:
+        enabled: false
   pep8:
     enabled: true
   radon:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,8 @@
+version: "2"
+checks:
+  method-count:
+    config:
+      threshold: 30
 plugins:
   sonar-python:
     enabled: true

--- a/src/telescope_baseline/tools/mission/parameters.py
+++ b/src/telescope_baseline/tools/mission/parameters.py
@@ -6,6 +6,9 @@ import pkg_resources
 
 from telescope_baseline.dataclass.efficiency import Efficiency
 
+
+# xxx
+
 class Parameters:
     """This class is parameter holder
 

--- a/src/telescope_baseline/tools/mission/parameters.py
+++ b/src/telescope_baseline/tools/mission/parameters.py
@@ -5,7 +5,6 @@ import numpy as np
 import pkg_resources
 
 from telescope_baseline.dataclass.efficiency import Efficiency
-# dummy comment
 
 class Parameters:
     """This class is parameter holder

--- a/src/telescope_baseline/tools/mission/parameters.py
+++ b/src/telescope_baseline/tools/mission/parameters.py
@@ -5,7 +5,7 @@ import numpy as np
 import pkg_resources
 
 from telescope_baseline.dataclass.efficiency import Efficiency
-
+# dummy comment
 
 class Parameters:
     """This class is parameter holder

--- a/src/telescope_baseline/tools/mission/parameters.py
+++ b/src/telescope_baseline/tools/mission/parameters.py
@@ -7,7 +7,7 @@ import pkg_resources
 from telescope_baseline.dataclass.efficiency import Efficiency
 
 
-# xxx
+# xxx_1
 
 class Parameters:
     """This class is parameter holder

--- a/src/telescope_baseline/tools/mission/parameters.py
+++ b/src/telescope_baseline/tools/mission/parameters.py
@@ -7,7 +7,7 @@ import pkg_resources
 from telescope_baseline.dataclass.efficiency import Efficiency
 
 
-# xxx_1
+# xxx_2
 
 class Parameters:
     """This class is parameter holder

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 90

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,2 @@
 [pycodestyle]
-max-line-length = 90
+max-line-length = 120


### PR DESCRIPTION
Codeclimateの閾値を以下の用に変更しました。

- １行当たりの文字数を120文字まで許容する
- Sonar-pythonの引数チェックを無効化する（二重に検証していたため）

