### PR TITLE
Feature/modify GitHub actions

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -23,7 +23,6 @@ runs:
       shell: bash
 
     - name: Generate Test Report Index
-      if: ${{ github.event_name == 'push' }}
       env:
         BRANCH: ${{ github.ref_name}}
         REPOSITORY: ${{ github.repository}}
@@ -39,14 +38,13 @@ runs:
       shell: bash
 
     - name: Publish Test Report
-      if: ${{ github.event_name == 'push' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ env.GITHUB_TOKEN }}
         publish_dir: ./pages
 
     - name: Send Coverage Report to CodeClimate
-      if: ${{ steps.pytest.outcome == 'success' && github.event_name == 'push'}}
+      if: ${{ steps.pytest.outcome == 'success'}}
       uses: paambaati/codeclimate-action@v3.0.0
       env:
         CC_TEST_REPORTER_ID: ${{ env.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ "main", "develop", "feature/modify_github_actions" ]
+    branches: [ "main", "develop" ]
   pull_request:
     branches: [ "main", "develop" ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: build
 
 on:
+  push:
+    branches: [ "main", "develop", "feature/modify_github_action" ]
   pull_request:
     branches: [ "main", "develop" ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ "main", "develop", "feature/modify_github_action" ]
+    branches: [ "main", "develop", "feature/modify_github_actions" ]
   pull_request:
     branches: [ "main", "develop" ]
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -18,7 +18,10 @@ jobs:
         BRANCH: ${{ github.event.ref}}
       run: |
         echo $BRANCH
-        rm -rf test_report/$BRANCH
+        echo ${BRANCH#refs/heads}
+        mkdir -p test_report/${BRANCH#refs/heads}
+        ls -al test_report
+#        rm -rf test_report/$BRANCH
       shell: bash
 
 #    - name: push pages

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,11 +1,12 @@
 name: cleanup
 
 on:
-  delete
+  push
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+
     steps:
     - name: checkout Pages branch
       uses: actions/checkout@v3

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,7 @@
 name: cleanup
 
 on:
-  push
+  delete
 
 jobs:
   cleanup:
@@ -19,8 +19,6 @@ jobs:
       run: |
         echo $BRANCH
         echo ${BRANCH#refs/heads/}
-        mkdir -p tmp/${BRANCH#refs/heads/}
-        ls -al tmp
 #        rm -rf test_report/$BRANCH
       shell: bash
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,33 @@
+name: cleanup
+
+on:
+  delete
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout Pages branch
+      uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+        path: pages
+      id: check_out_pages_branch
+      continue-on-error: true
+
+    - name: Cleanup per branch information
+      env:
+        BRANCH: ${{ github.ref_name}}
+      id: pytest
+      continue-on-error: true
+      run: |
+        rm -rf pages/test_report/$BRANCH
+      shell: bash
+
+    - name: push pages
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ env.GITHUB_TOKEN }}
+        publish_dir: ./pages

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,23 +11,19 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: gh-pages
-        path: pages
-      id: check_out_pages_branch
-      continue-on-error: true
 
     - name: Cleanup per branch information
       env:
-        BRANCH: ${{ github.ref_name}}
-      id: pytest
-      continue-on-error: true
+        BRANCH: ${{ github.event.ref}}
       run: |
-        rm -rf pages/test_report/$BRANCH
+        echo $BRANCH
+        rm -rf test_report/$BRANCH
       shell: bash
 
-    - name: push pages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ env.GITHUB_TOKEN }}
-        publish_dir: ./pages
+#    - name: push pages
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      uses: peaceiris/actions-gh-pages@v3
+#      with:
+#        github_token: ${{ env.GITHUB_TOKEN }}
+#        publish_dir: ./pages

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -18,9 +18,9 @@ jobs:
         BRANCH: ${{ github.event.ref}}
       run: |
         echo $BRANCH
-        echo ${BRANCH#refs/heads}
-        mkdir -p test_report/${BRANCH#refs/heads}
-        ls -al test_report
+        echo ${BRANCH#refs/heads/}
+        mkdir -p tmp/${BRANCH#refs/heads/}
+        ls -al tmp
 #        rm -rf test_report/$BRANCH
       shell: bash
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,13 +19,15 @@ jobs:
       run: |
         echo $BRANCH
         echo ${BRANCH#refs/heads/}
-#        rm -rf test_report/$BRANCH
+        mkdir -p tmp/${BRANCH#refs/heads/}
+        ls -al tmp
+        rm -rf test_report/${BRANCH#refs/heads/}
       shell: bash
 
-#    - name: push pages
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      uses: peaceiris/actions-gh-pages@v3
-#      with:
-#        github_token: ${{ env.GITHUB_TOKEN }}
-#        publish_dir: ./pages
+    - name: push pages
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ env.GITHUB_TOKEN }}
+        publish_dir: ./pages

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,7 @@ name: pytest
 
 on:
   push
+    branches: [ "main", "develop" ]
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: pytest
 
 on:
-  push
+  push:
     branches: [ "main", "develop" ]
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,8 +2,6 @@ name: pytest
 
 on:
   push:
-  pull_request:
-    branches: [ "main", "develop" ]
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: pytest
 
 on:
-  push:
+  push
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,8 +1,7 @@
 name: pytest
 
 on:
-  push:
-    branches: [ "main", "develop" ]
+  push
 
 jobs:
   pytest:


### PR DESCRIPTION
以下の対応をしております。

- ブランチ削除時にテストレポートから当該のリポジトリのレポートを消せるようにする
- testはpush時のみ
- develop、mainのpush時にbuildを走らせる

但し、テストレポートの削除は動作確認できていません。
ブランチ削除のワークフローはデフォルトブランチ(多分main?)にワークフローファイルを置かないと動作しないようです。

https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#delete


