### PR TITLE
Feature/slowtest

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -60,9 +60,7 @@ runs:
       with:
         payload: |
           {
-            "text": |
-              ${{ github.ref_name}}で${{ env.TEST_DIR}}配下のテストが全件パスしませんでした。
-              詳細はGithub上のActionsページで直近のエラーとなっているActionを参照ください。
+            "text": "${{ github.ref_name}}で${{ env.TEST_DIR}}配下のテストが全件パスしませんでした。\n詳細はGithub上のActionsページで直近のエラーとなっているActionを参照ください。"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -14,12 +14,14 @@ runs:
       shell: bash
 
     - name: checkout Pages branch
+      if: ${{ env.TEST_ONLY != 'true'}}
       uses: actions/checkout@v3
       with:
         ref: gh-pages
         path: pages
 
     - name: Generate Test Report Index
+      if: ${{ env.TEST_ONLY != 'true'}}
       env:
         BRANCH: ${{ github.ref_name}}
         REPOSITORY: ${{ github.repository}}
@@ -44,7 +46,7 @@ runs:
         keep_files: true
 
     - name: Send Coverage Report to CodeClimate
-      if: ${{ steps.pytest.outcome == 'success'}}
+      if: ${{ steps.pytest.outcome == 'success' && env.TEST_ONLY != 'true'}}
       uses: paambaati/codeclimate-action@v3.0.0
       env:
         CC_TEST_REPORTER_ID: ${{ env.CC_TEST_REPORTER_ID }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,12 +4,13 @@ runs:
     - name: Test with pytest
       env:
         BRANCH: ${{ github.ref_name}}
+        TEST_DIR: ${{ env.TEST_DIR}}
       id: pytest
       continue-on-error: true
       run: |
-        export PYTHONPATH=./src:./tests:$PYTHONPATH
+        export PYTHONPATH=./src:./tests:./$TEST_DIR:$PYTHONPATH
         python -m pip install pytest pytest-html pytest-cov
-        python -m pytest tests --junitxml=test_report/$BRANCH/pytest.xml --html=test_report/$BRANCH/pytest.html --cov=src --cov-branch --cov-report=term-missing --cov-report=html --cov-report xml
+        python -m pytest $TEST_DIR --junitxml=test_report/$BRANCH/pytest.xml --html=test_report/$BRANCH/pytest.html --cov=src --cov-branch --cov-report=term-missing --cov-report=html --cov-report xml
       shell: bash
 
     - name: checkout Pages branch

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -36,6 +36,7 @@ runs:
       shell: bash
 
     - name: Publish Test Report
+      if: ${{ env.TEST_ONLY != 'true'}}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ env.GITHUB_TOKEN }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -60,7 +60,9 @@ runs:
       with:
         payload: |
           {
-            "text": "TEST FAILED!!!!"
+            "text": |
+              ${{ github.ref_name}}で${{ env.TEST_DIR}}配下のテストが全件パスしませんでした。
+              詳細はGithub上のActionsページで直近のエラーとなっているActionを参照ください。
           }
       env:
         SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -54,6 +54,17 @@ runs:
         debug: false
         coverageLocations: coverage.xml:coverage.py
 
+    - name: Notice Slack
+      if: ${{ steps.pytest.outcome == 'failure' }}
+      uses: slackapi/slack-github-action@v1.21.0
+      with:
+        payload: |
+          {
+            "text": "TEST FAILED!!!!"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL}}
+
     - name: Notice Error
       if: ${{ steps.pytest.outcome == 'failure' }}
       run: exit 1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,6 +21,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         TEST_DIR: tests
       uses: ./.github/actions/test
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,6 +22,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         TEST_DIR: tests
-        TEST_ONLY: true
       uses: ./.github/actions/test
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,5 +22,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         TEST_DIR: tests
+        TEST_ONLY: true
       uses: ./.github/actions/test
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,5 +21,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        TEST_DIR: tests
       uses: ./.github/actions/test
 

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,7 +1,7 @@
 name: slowtest
 
 on:
-  push:                   # temporary
+  workflow_dispatch:
   schedule:
     - cron: '0 13 * * *'  # UTC 13:00 -> JST(22:00)
 

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,0 +1,11 @@
+name: slowtest
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  slowtest:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "execution slow test!!!!"

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,6 +1,7 @@
 name: slowtest
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '*/5 * * * *'
 

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,6 +1,7 @@
 name: slowtest
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: '0 13 * * *'  # UTC 13:00 -> JST(22:00)
@@ -21,6 +22,7 @@ jobs:
 
     - name: test
       env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         TEST_DIR: slowtests
         TEST_ONLY: true
       uses: ./.github/actions/test

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -8,5 +8,19 @@ on:
 jobs:
   slowtest:
     runs-on: ubuntu-latest
+
     steps:
-      - run: echo "execution slow test!!!!"
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+
+    - name: get dependencies
+      uses: ./.github/actions/get_dependencies
+
+    - name: test
+      env:
+        TEST_DIR: slowtests
+        TEST_ONLY: true
+      uses: ./.github/actions/test

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,9 +1,8 @@
 name: slowtest
 
 on:
-  push
-#  schedule:
-#    - cron: '*/5 * * * *'
+  schedule:
+    - cron: '*/5 * * * *'
 
 
 jobs:

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,8 +1,10 @@
 name: slowtest
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  push
+#  schedule:
+#    - cron: '*/5 * * * *'
+
 
 jobs:
   slowtest:

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,10 +1,9 @@
 name: slowtest
 
 on:
-  workflow_dispatch:
+  push:                   # temporary
   schedule:
-    - cron: '*/5 * * * *'
-
+    - cron: '0 13 * * *'  # UTC 13:00 -> JST(22:00)
 
 jobs:
   slowtest:

--- a/slowtests/test_slow_test_example.py
+++ b/slowtests/test_slow_test_example.py
@@ -4,5 +4,5 @@ from test_tools.assert_timeout import assert_timeout
 
 
 def test_slow():
-    # assert_timeout(10 * 1000, lambda: time.sleep(5))  # not error
-    assert_timeout(4 * 1000, lambda: time.sleep(5))    # error
+    assert_timeout(10 * 1000, lambda: time.sleep(5))  # not error
+    # assert_timeout(4 * 1000, lambda: time.sleep(5))    # error

--- a/slowtests/test_slow_test_example.py
+++ b/slowtests/test_slow_test_example.py
@@ -1,0 +1,9 @@
+import pytest
+import time
+from test_tools.assert_timeout import assert_timeout
+
+
+def test_slow():
+    slow_func = lambda: time.sleep(5)
+    assert_timeout(10 * 1000, slow_func)    # not error
+    #assert_timeout(4 * 1000, slow_func)    # error

--- a/slowtests/test_slow_test_example.py
+++ b/slowtests/test_slow_test_example.py
@@ -4,6 +4,5 @@ from test_tools.assert_timeout import assert_timeout
 
 
 def test_slow():
-    slow_func = lambda: time.sleep(5)
-    assert_timeout(10 * 1000, slow_func)    # not error
-    #assert_timeout(4 * 1000, slow_func)    # error
+    assert_timeout(10 * 1000, lambda: time.sleep(5))  # not error
+    # assert_timeout(4 * 1000, lambda: time.sleep(5))    # error

--- a/slowtests/test_slow_test_example.py
+++ b/slowtests/test_slow_test_example.py
@@ -5,5 +5,5 @@ from test_tools.assert_timeout import assert_timeout
 
 def test_slow():
     slow_func = lambda: time.sleep(5)
-    assert_timeout(10 * 1000, slow_func)    # not error
-    #assert_timeout(4 * 1000, slow_func)    # error
+    #assert_timeout(10 * 1000, slow_func)    # not error
+    assert_timeout(4 * 1000, slow_func)    # error

--- a/slowtests/test_slow_test_example.py
+++ b/slowtests/test_slow_test_example.py
@@ -5,5 +5,5 @@ from test_tools.assert_timeout import assert_timeout
 
 def test_slow():
     slow_func = lambda: time.sleep(5)
-    #assert_timeout(10 * 1000, slow_func)    # not error
-    assert_timeout(4 * 1000, slow_func)    # error
+    assert_timeout(10 * 1000, slow_func)    # not error
+    #assert_timeout(4 * 1000, slow_func)    # error

--- a/slowtests/test_slow_test_example.py
+++ b/slowtests/test_slow_test_example.py
@@ -4,5 +4,5 @@ from test_tools.assert_timeout import assert_timeout
 
 
 def test_slow():
-    assert_timeout(10 * 1000, lambda: time.sleep(5))  # not error
-    # assert_timeout(4 * 1000, lambda: time.sleep(5))    # error
+    # assert_timeout(10 * 1000, lambda: time.sleep(5))  # not error
+    assert_timeout(4 * 1000, lambda: time.sleep(5))    # error

--- a/tests/test_tools/assert_timeout.py
+++ b/tests/test_tools/assert_timeout.py
@@ -2,6 +2,23 @@ import time
 
 
 def assert_timeout(timeout_milliseconds: int, func):
+    """Measure the time for a specific process and send an AssertionError if it exceeds the threshold value.
+
+    Args:
+        timeout_milliseconds:Timeout threshold(milli seconds)
+        func:Measured Processing
+
+    Returns:
+        Return value of func. If there is no return value, return None.
+
+    Exaples:
+
+        >>> from test_tools.assert_timeout import assert_timeout
+        >>> func = lambda : time.sleep(1.1)
+        >>> assert_timeout(2000, func)  # not thrown AssertionError
+        >>> assert_timeout(1000, func)  # thrown AssertionError
+
+    """
     start = time.time() * 1000
     ret = func()
     end = time.time() * 1000

--- a/tests/test_tools/assert_timeout.py
+++ b/tests/test_tools/assert_timeout.py
@@ -1,0 +1,11 @@
+import time
+
+
+def assert_timeout(timeout_milliseconds: int, func):
+    start = time.time() * 1000
+    ret = func()
+    end = time.time() * 1000
+    period = end - start
+    if period > timeout_milliseconds:
+        raise AssertionError('timeout:limit:[%d]ms actual:[%d]ms' % (timeout_milliseconds, period))
+    return ret

--- a/tests/test_tools/assert_timeout_test.py
+++ b/tests/test_tools/assert_timeout_test.py
@@ -1,0 +1,30 @@
+import pytest
+import time
+from test_tools.assert_timeout import assert_timeout
+
+
+def test_assert_timeout__return_value():
+    func = lambda: 3
+    ret = assert_timeout(1000, func)
+    assert ret == 3
+
+
+def dummy_func():
+    pass
+
+def test_assert_timeout__void_func():
+    func = dummy_func
+    ret = assert_timeout(1000, func)
+    assert ret == None
+
+
+def test_assert_timeout__timeout():
+    func = lambda : time.sleep(1.1)
+    try:
+        assert_timeout(1000, func)
+        print('タイムアウトせず')
+    except AssertionError:
+        print('タイムアウトした!!')
+        return
+    assert 1 == 2, "タイムアウトしていません"
+


### PR DESCRIPTION
遅いテストや性能検証をするためのワークフローを作成しました。
基本的には、GithubActionsの修正ですが、特定の処理ブロックが一定時間で終わらない場合にエラーとなるような関数を追加しております。（assert_timeout.py)
いくつか懸念事項があるので、ドラフトにしております。判断を仰ぎたいです。

- 定点実行（今は日本時間22:00)で動くようにしてますが、動いた実績がありません。これは経過観察です。5分間隔指定の時は動かなかった...
- 通常のテストはコケてる場合は、PullRequestや、TestReportで確認できますが、こちらのテストではレポート表記していないので、エラーになったことの通知が必要になります。https://github.com/slackapi/slack-github-action を利用すればいけそうですが、今の連携でもっと簡単にできませんかね？出来ないなら作り込む必要がありますので、SLACK_WEBHOOK_URLの設定をして欲しいです。（CodeClimateの設定でお願いした時と同様の方法で）
- 今は全ブランチで動くようになっていますが、develop(main?)に絞った方が良いかも知れません。個別ブランチで実行する場合は、workflow_dispatchでできるようにしてもいいかなと思います（なお、workflow_dispatchを有効にするにはmainブランチまで上げる必要があります。。。）

