### PR TITLE
ブランチ削除時にテストレポートが消えてしまう不具合の修正

### DIFF
--- a/.github/actions/rebuild_testreport_index/action.yml
+++ b/.github/actions/rebuild_testreport_index/action.yml
@@ -3,7 +3,6 @@ runs:
   steps:
     - name: Rebuilding Test Report Index Page
       env:
-        BRANCH: ${{ github.ref_name}}
         REPOSITORY: ${{ github.repository}}
       run: |
         pushd pages/test_report

--- a/.github/actions/rebuild_testreport_index/action.yml
+++ b/.github/actions/rebuild_testreport_index/action.yml
@@ -1,0 +1,15 @@
+runs:
+  using: "Composite"
+  steps:
+    - name: Rebuilding Test Report Index Page
+      env:
+        BRANCH: ${{ github.ref_name}}
+        REPOSITORY: ${{ github.repository}}
+      run: |
+        pushd pages/test_report
+        echo "<html><head><title>JASMINE Testing Report</title></head><body><h1>JASMINE TESTING REPORT</h1><ul>" > index.html
+        find . -name pytest.html | xargs -Ixxx dirname xxx | awk '{print substr($0, 3)}' | xargs -Ixxx echo "<li><a href=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml?query=branch:xxx\"><img src=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml/badge.svg?branch=xxx\" alt=\"pytest\" style=\"max-width: 100%;\"></a>xxx<a href=\"xxx/pytest.html\">(Test Report)</a><a href=\"xxx/htmlcov/index.html\">(Test Coverage Report)</a></li>" >> index.html
+        echo "</ul></body></html>" >> index.html
+        cat index.html
+        popd
+      shell: bash

--- a/.github/actions/rebuild_testreport_index/action.yml
+++ b/.github/actions/rebuild_testreport_index/action.yml
@@ -10,6 +10,5 @@ runs:
         echo "<html><head><title>JASMINE Testing Report</title></head><body><h1>JASMINE TESTING REPORT</h1><ul>" > index.html
         find . -name pytest.html | xargs -Ixxx dirname xxx | awk '{print substr($0, 3)}' | xargs -Ixxx echo "<li><a href=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml?query=branch:xxx\"><img src=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml/badge.svg?branch=xxx\" alt=\"pytest\" style=\"max-width: 100%;\"></a>xxx<a href=\"xxx/pytest.html\">(Test Report)</a><a href=\"xxx/htmlcov/index.html\">(Test Coverage Report)</a></li>" >> index.html
         echo "</ul></body></html>" >> index.html
-        cat index.html
         popd
       shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -29,7 +29,12 @@ runs:
         rm -rf pages/test_report/$BRANCH
         cp -r test_report/* pages/test_report
         mv htmlcov pages/test_report/$BRANCH/
+        ls -al pages/test_report/$BRANCH/
       shell: bash
+
+    - name: Rebuild Test Report Index Page
+      if: ${{ env.TEST_ONLY != 'true'}}
+      uses: ../rebuild_testreport_index
 
 #      env:
 #        BRANCH: ${{ github.ref_name}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Rebuild Test Report Index Page
       if: ${{ env.TEST_ONLY != 'true'}}
-      uses: ../rebuild_testreport_index
+      uses: ./.github/actions/rebuild_testreport_index
 
 #      env:
 #        BRANCH: ${{ github.ref_name}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -20,30 +20,44 @@ runs:
         ref: gh-pages
         path: pages
 
-    - name: Generate Test Report Index
+    - name: Move Test Reporting Files
       if: ${{ env.TEST_ONLY != 'true'}}
       env:
         BRANCH: ${{ github.ref_name}}
-        REPOSITORY: ${{ github.repository}}
       run: |
         rm htmlcov/.gitignore
         rm -rf pages/test_report/$BRANCH
         cp -r test_report/* pages/test_report
         mv htmlcov pages/test_report/$BRANCH/
-        pushd pages/test_report
-        echo "<html><head><title>JASMINE Testing Report</title></head><body><h1>JASMINE TESTING REPORT</h1><ul>" > index.html
-        find . -name pytest.html | xargs -Ixxx dirname xxx | awk '{print substr($0, 3)}' | xargs -Ixxx echo "<li><a href=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml?query=branch:xxx\"><img src=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml/badge.svg?branch=xxx\" alt=\"pytest\" style=\"max-width: 100%;\"></a>xxx<a href=\"xxx/pytest.html\">(Test Report)</a><a href=\"xxx/htmlcov/index.html\">(Test Coverage Report)</a></li>" >> index.html
-        echo "</ul></body></html>" >> index.html
-        popd
-      shell: bash
 
-    - name: Publish Test Report
-      if: ${{ env.TEST_ONLY != 'true'}}
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ env.GITHUB_TOKEN }}
-        publish_dir: ./pages
-        keep_files: true
+#      env:
+#        BRANCH: ${{ github.ref_name}}
+#        REPOSITORY: ${{ github.repository}}
+
+#    - name: Generate Test Report Index
+#      if: ${{ env.TEST_ONLY != 'true'}}
+#      env:
+#        BRANCH: ${{ github.ref_name}}
+#        REPOSITORY: ${{ github.repository}}
+#      run: |
+#        rm htmlcov/.gitignore
+#        rm -rf pages/test_report/$BRANCH
+#        cp -r test_report/* pages/test_report
+#        mv htmlcov pages/test_report/$BRANCH/
+#        pushd pages/test_report
+#        echo "<html><head><title>JASMINE Testing Report</title></head><body><h1>JASMINE TESTING REPORT</h1><ul>" > index.html
+#        find . -name pytest.html | xargs -Ixxx dirname xxx | awk '{print substr($0, 3)}' | xargs -Ixxx echo "<li><a href=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml?query=branch:xxx\"><img src=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml/badge.svg?branch=xxx\" alt=\"pytest\" style=\"max-width: 100%;\"></a>xxx<a href=\"xxx/pytest.html\">(Test Report)</a><a href=\"xxx/htmlcov/index.html\">(Test Coverage Report)</a></li>" >> index.html
+#        echo "</ul></body></html>" >> index.html
+#        popd
+#      shell: bash
+
+#    - name: Publish Test Report
+#      if: ${{ env.TEST_ONLY != 'true'}}
+#      uses: peaceiris/actions-gh-pages@v3
+#      with:
+#        github_token: ${{ env.GITHUB_TOKEN }}
+#        publish_dir: ./pages
+#        keep_files: true
 
     - name: Send Coverage Report to CodeClimate
       if: ${{ steps.pytest.outcome == 'success' && env.TEST_ONLY != 'true'}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -29,6 +29,7 @@ runs:
         rm -rf pages/test_report/$BRANCH
         cp -r test_report/* pages/test_report
         mv htmlcov pages/test_report/$BRANCH/
+      shell: bash
 
 #      env:
 #        BRANCH: ${{ github.ref_name}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -36,34 +36,13 @@ runs:
       if: ${{ env.TEST_ONLY != 'true'}}
       uses: ./.github/actions/rebuild_testreport_index
 
-#      env:
-#        BRANCH: ${{ github.ref_name}}
-#        REPOSITORY: ${{ github.repository}}
-
-#    - name: Generate Test Report Index
-#      if: ${{ env.TEST_ONLY != 'true'}}
-#      env:
-#        BRANCH: ${{ github.ref_name}}
-#        REPOSITORY: ${{ github.repository}}
-#      run: |
-#        rm htmlcov/.gitignore
-#        rm -rf pages/test_report/$BRANCH
-#        cp -r test_report/* pages/test_report
-#        mv htmlcov pages/test_report/$BRANCH/
-#        pushd pages/test_report
-#        echo "<html><head><title>JASMINE Testing Report</title></head><body><h1>JASMINE TESTING REPORT</h1><ul>" > index.html
-#        find . -name pytest.html | xargs -Ixxx dirname xxx | awk '{print substr($0, 3)}' | xargs -Ixxx echo "<li><a href=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml?query=branch:xxx\"><img src=\"https://github.com/$REPOSITORY/actions/workflows/pytest.yml/badge.svg?branch=xxx\" alt=\"pytest\" style=\"max-width: 100%;\"></a>xxx<a href=\"xxx/pytest.html\">(Test Report)</a><a href=\"xxx/htmlcov/index.html\">(Test Coverage Report)</a></li>" >> index.html
-#        echo "</ul></body></html>" >> index.html
-#        popd
-#      shell: bash
-
-#    - name: Publish Test Report
-#      if: ${{ env.TEST_ONLY != 'true'}}
-#      uses: peaceiris/actions-gh-pages@v3
-#      with:
-#        github_token: ${{ env.GITHUB_TOKEN }}
-#        publish_dir: ./pages
-#        keep_files: true
+    - name: Publish Test Report
+      if: ${{ env.TEST_ONLY != 'true'}}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ env.GITHUB_TOKEN }}
+        publish_dir: ./pages
+        keep_files: true
 
     - name: Send Coverage Report to CodeClimate
       if: ${{ steps.pytest.outcome == 'success' && env.TEST_ONLY != 'true'}}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: checkout this branch
+    - uses: actions/checkout@v3
+
     - name: checkout Pages branch
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -23,8 +23,6 @@ jobs:
       run: |
         echo $BRANCH
         rm -rf pages/test_report/${BRANCH#refs/heads/}
-        ls -altr pages/test_report/
-        ls -altr pages/test_report/bugfix
       shell: bash
 
     - name: Rebuild Test Report Index Page

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,8 +1,8 @@
 name: cleanup
 
 on:
-  push
-  delete
+  push:
+  delete:
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,6 +1,7 @@
 name: cleanup
 
 on:
+  push
   delete
 
 jobs:
@@ -12,23 +13,26 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: gh-pages
+        path: pages
 
     - name: Cleanup per branch information
       env:
         BRANCH: ${{ github.event.ref}}
       run: |
         echo $BRANCH
-        echo ${BRANCH#refs/heads/}
-        mkdir -p tmp/${BRANCH#refs/heads/}
-        ls -al tmp
-        rm -rf test_report/${BRANCH#refs/heads/}
+        rm -rf pages/test_report/${BRANCH#refs/heads/}
+        ls -altr pafes/test_report/
+        ls -altr pafes/test_report/bugfix
       shell: bash
 
-    - name: push pages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ env.GITHUB_TOKEN }}
-        publish_dir: ./pages
-        keep_files: true
+    - name: Rebuild Test Report Index Page
+      uses: ./.github/actions/rebuild_testreport_index
+
+#    - name: push pages
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      uses: peaceiris/actions-gh-pages@v3
+#      with:
+#        github_token: ${{ env.GITHUB_TOKEN }}
+#        publish_dir: ./pages
+#        keep_files: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -21,8 +21,8 @@ jobs:
       run: |
         echo $BRANCH
         rm -rf pages/test_report/${BRANCH#refs/heads/}
-        ls -altr pafes/test_report/
-        ls -altr pafes/test_report/bugfix
+        ls -altr pages/test_report/
+        ls -altr pages/test_report/bugfix
       shell: bash
 
     - name: Rebuild Test Report Index Page

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -31,3 +31,4 @@ jobs:
       with:
         github_token: ${{ env.GITHUB_TOKEN }}
         publish_dir: ./pages
+        keep_files: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: checkout this branch
-    - uses: actions/checkout@v3
+      uses: actions/checkout@v3
 
     - name: checkout Pages branch
       uses: actions/checkout@v3

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,6 @@
 name: cleanup
 
 on:
-  push:
   delete:
 
 jobs:
@@ -31,11 +30,11 @@ jobs:
     - name: Rebuild Test Report Index Page
       uses: ./.github/actions/rebuild_testreport_index
 
-#    - name: push pages
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      uses: peaceiris/actions-gh-pages@v3
-#      with:
-#        github_token: ${{ env.GITHUB_TOKEN }}
-#        publish_dir: ./pages
-#        keep_files: true
+    - name: push pages
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ env.GITHUB_TOKEN }}
+        publish_dir: ./pages
+        keep_files: true

--- a/.github/workflows/slowtest.yml
+++ b/.github/workflows/slowtest.yml
@@ -1,7 +1,6 @@
 name: slowtest
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 13 * * *'  # UTC 13:00 -> JST(22:00)


### PR DESCRIPTION
ブランチ削除時にテストレポートが前消しされてしまう不具合を解消しました（最終動作確認は出来ないので多分ですが...）

レビュー観点：

- 直接的な原因は、cleanup.ymlでpeaceiris/actions-gh-pages@v3実行時のパラメータにkeep_fileを付け忘れていたためだと思われます。(publish_dirも違ってましたね...) 
- 処理的にはファイルを消す処理はあっても、その後のインデックスファイルを作り直す処理は記述漏れをしていたので、書き足しています。
- 上記処理は、テスト終了時と同じ処理になるので、テストレポートを作る処理はさらにsubaction化して共通化しました
- このプルリクでは行うべきではないのですが、プルリク処理の労力削減目的でslowtestのトリガーミス（pushでも動くようになっていました...）の修正も行っています


