### PR TITLE
テストデータ読み込み処理をシンプルにする

### DIFF
--- a/tests/pipeline/test_astrometric_catalogue.py
+++ b/tests/pipeline/test_astrometric_catalogue.py
@@ -1,12 +1,11 @@
 import csv
 import pytest
-import tempfile
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from telescope_baseline.tools.pipeline.astrometric_catalogue import AstrometricCatalogue
 from telescope_baseline.tools.pipeline.catalog_entry import CatalogueEntry
 from test_pipeline import get_tests_file_name
-
+from test_tools.test_file_utils import get_temp_file
 
 @pytest.fixture
 def csv_line():
@@ -16,12 +15,12 @@ def csv_line():
                                 distance=1.0 * u.pc, pm_l_cosb=10 * u.mas / u.yr, pm_b=10 * u.mas / u.yr),
                        12.5),
     ])
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        f_name = tmp_file.name
-        a.save(f_name)
-        file = open(f_name, 'r', newline='')
-        f = csv.reader(file, delimiter=',')
-        return next(iter(f))
+    tmp_file = get_temp_file()
+    f_name = str(tmp_file)
+    a.save(f_name)
+    file = open(f_name, 'r', newline='')
+    f = csv.reader(file, delimiter=',')
+    return next(iter(f))
 
 
 def test_save1(csv_line):

--- a/tests/pipeline/test_astrometric_catalogue.py
+++ b/tests/pipeline/test_astrometric_catalogue.py
@@ -1,5 +1,6 @@
 import csv
 import pytest
+import tempfile
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from telescope_baseline.tools.pipeline.astrometric_catalogue import AstrometricCatalogue
@@ -9,17 +10,18 @@ from test_pipeline import get_tests_file_name
 
 @pytest.fixture
 def csv_line():
-    f_name = str(get_tests_file_name('a.csv', folder='tmp'))
     a = AstrometricCatalogue([
         CatalogueEntry(1,
                        SkyCoord(l=0., b=0., unit=('rad', 'rad'), frame='galactic', obstime='2000-01-01 00:00:00.0',
                                 distance=1.0 * u.pc, pm_l_cosb=10 * u.mas / u.yr, pm_b=10 * u.mas / u.yr),
                        12.5),
     ])
-    a.save(f_name)
-    file = open(f_name, 'r', newline='')
-    f = csv.reader(file, delimiter=',')
-    return next(iter(f))
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        f_name = tmp_file.name
+        a.save(f_name)
+        file = open(f_name, 'r', newline='')
+        f = csv.reader(file, delimiter=',')
+        return next(iter(f))
 
 
 def test_save1(csv_line):

--- a/tests/pipeline/test_map_on_detector.py
+++ b/tests/pipeline/test_map_on_detector.py
@@ -1,5 +1,6 @@
 import csv
 import pytest
+import tempfile
 from astropy.time import Time
 from astropy.wcs import WCS
 from telescope_baseline.tools.pipeline.map_on_detector import MapOnDetector
@@ -17,11 +18,11 @@ def mod():
 
 @pytest.fixture
 def csv_read(mod):
-    f_name = get_tests_file_name('a.csv', folder="tmp")
-    mod.save(f_name)
-    file = open(f_name, 'r', newline='')
-    f = csv.reader(file, delimiter=',')
-    return next(iter(f))
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        mod.save(tmp_file.name)
+        file = open(tmp_file.name, 'r', newline='')
+        f = csv.reader(file, delimiter=',')
+        return next(iter(f))
 
 
 def test_save1(csv_read):

--- a/tests/pipeline/test_map_on_detector.py
+++ b/tests/pipeline/test_map_on_detector.py
@@ -1,6 +1,5 @@
 import csv
 import pytest
-import tempfile
 from astropy.time import Time
 from astropy.wcs import WCS
 from telescope_baseline.tools.pipeline.map_on_detector import MapOnDetector
@@ -8,6 +7,7 @@ from telescope_baseline.tools.pipeline.map_on_the_sky_builder import MapOnTheSky
 from telescope_baseline.tools.pipeline.position2d import Position2D
 from telescope_baseline.tools.pipeline.position_on_detector import PositionOnDetector
 from test_pipeline import get_tests_file_name
+from test_tools.test_file_utils import get_temp_file
 
 
 @pytest.fixture
@@ -18,11 +18,12 @@ def mod():
 
 @pytest.fixture
 def csv_read(mod):
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        mod.save(tmp_file.name)
-        file = open(tmp_file.name, 'r', newline='')
-        f = csv.reader(file, delimiter=',')
-        return next(iter(f))
+    tmp_file = get_temp_file()
+    file_name = str(tmp_file)
+    mod.save(file_name)
+    file = open(file_name, 'r', newline='')
+    f = csv.reader(file, delimiter=',')
+    return next(iter(f))
 
 
 def test_save1(csv_read):

--- a/tests/pipeline/test_map_on_the_sky.py
+++ b/tests/pipeline/test_map_on_the_sky.py
@@ -1,5 +1,6 @@
 import csv
 import pytest
+import tempfile
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from telescope_baseline.tools.pipeline.map_on_the_sky import MapOnTheSky
@@ -15,42 +16,21 @@ def mos():
     return m
 
 
-@pytest.fixture
-def file(mos):
-    f_name = str(get_tests_file_name('a.csv', folder="tmp"))
-    mos.save(f_name)
-    return open(f_name, 'r', newline='')
-
-
-def test_save1(file):
-    csv_line = csv.reader(file, delimiter=',')
-    for r in csv_line:
-        if len(r) == 1:
-            assert int(r[0]) == -1
-
-
-def test_save2(file):
-    csv_line = csv.reader(file, delimiter=',')
-    for r in csv_line:
-        if len(r) != 1:
-            assert int(r[0]) == 1
-            assert abs(float(r[1]) - 4.649644189337132) < 0.001
-
-
-def test_save3(file):
-    csv_line = csv.reader(file, delimiter=',')
-    for r in csv_line:
-        if len(r) != 1:
-            assert abs(float(r[2]) + 0.5050315748856247) < 0.001
-            assert abs(float(r[3]) - 12.5) < 0.1
-
-
-def test_save4(file):
-    csv_line = csv.reader(file, delimiter=',')
-    for r in csv_line:
-        if len(r) != 1:
-            assert abs(float(r[3]) - 12.5) < 0.1
-            assert r[4] == '2000-01-01 00:00:00.000'
+def test_save(mos):
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        f_name = tmp_file.name
+        mos.save(f_name)
+        file = open(f_name, 'r', newline='')
+        csv_line = csv.reader(file, delimiter=',')
+        for r in csv_line:
+            if len(r) == 1:
+                assert int(r[0]) == -1
+            else:
+                assert int(r[0]) == 1
+                assert abs(float(r[1]) - 4.649644189337132) < 0.001
+                assert abs(float(r[2]) + 0.5050315748856247) < 0.001
+                assert abs(float(r[3]) - 12.5) < 0.1
+                assert r[4] == '2000-01-01 00:00:00.000'
 
 
 @pytest.fixture

--- a/tests/pipeline/test_map_on_the_sky.py
+++ b/tests/pipeline/test_map_on_the_sky.py
@@ -1,11 +1,11 @@
 import csv
 import pytest
-import tempfile
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from telescope_baseline.tools.pipeline.map_on_the_sky import MapOnTheSky
 from telescope_baseline.tools.pipeline.position_on_the_sky import PositionOnTheSky
 from test_pipeline import get_tests_file_name
+from test_tools.test_file_utils import get_temp_file
 
 
 @pytest.fixture
@@ -17,20 +17,20 @@ def mos():
 
 
 def test_save(mos):
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        f_name = tmp_file.name
-        mos.save(f_name)
-        file = open(f_name, 'r', newline='')
-        csv_line = csv.reader(file, delimiter=',')
-        for r in csv_line:
-            if len(r) == 1:
-                assert int(r[0]) == -1
-            else:
-                assert int(r[0]) == 1
-                assert abs(float(r[1]) - 4.649644189337132) < 0.001
-                assert abs(float(r[2]) + 0.5050315748856247) < 0.001
-                assert abs(float(r[3]) - 12.5) < 0.1
-                assert r[4] == '2000-01-01 00:00:00.000'
+    tmp_file = get_temp_file()
+    f_name = str(tmp_file)
+    mos.save(f_name)
+    file = open(f_name, 'r', newline='')
+    csv_line = csv.reader(file, delimiter=',')
+    for r in csv_line:
+        if len(r) == 1:
+            assert int(r[0]) == -1
+        else:
+            assert int(r[0]) == 1
+            assert abs(float(r[1]) - 4.649644189337132) < 0.001
+            assert abs(float(r[2]) + 0.5050315748856247) < 0.001
+            assert abs(float(r[3]) - 12.5) < 0.1
+            assert r[4] == '2000-01-01 00:00:00.000'
 
 
 @pytest.fixture

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -11,7 +11,7 @@ from telescope_baseline.tools.pipeline.wcswid import WCSwId
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs import WCS
-from pathlib import Path
+from test_tools.test_file_utils import get_test_file
 
 
 def test_simulation():
@@ -39,18 +39,7 @@ def test_simulation():
 
 
 def get_tests_file_name(fname: str, folder='data'):
-    a = Path.cwd()
-    tests_dir = 'tests/pipeline'    # change it when test dir move
-    if 'telescope_baseline' not in str(a):
-        return Path(a, tests_dir, folder, fname)
-    while a.name != 'telescope_baseline':
-        a = a.parent
-    if folder != 'data':
-        tmp_path = Path(a, tests_dir, folder)
-        if not tmp_path.exists():
-            tmp_path.mkdir()
-    file = Path(a, tests_dir, folder, fname)
-    return file
+    return get_test_file(f'pipeline/{folder}/{fname}')
 
 
 def test_analysis():

--- a/tests/test_tools/test_file_utils.py
+++ b/tests/test_tools/test_file_utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import sys
+import os
+import tempfile
 
 
 def get_test_file(file_path: str) -> Path:
@@ -8,3 +10,40 @@ def get_test_file(file_path: str) -> Path:
         if target_file.exists():
             return target_file
     raise FileNotFoundError()
+
+
+class _PathWrapper:
+    def __init__(self, origin:Path, delete_when_gc):
+        self.__origin = origin
+        self.__delete_when_gc = delete_when_gc
+
+    def __getattr__(self, name):
+        def func(*args, **kwargs):
+            return getattr(self.__origin, name)(*args, **kwargs)
+        return func
+
+    def __repr__(self):
+        return repr(self.__origin)
+
+    def __bytes__(self):
+        return bytes(self.__origin)
+
+    def __str__(self):
+        return str(self.__origin)
+
+    def __format__(self, form_spec):
+        return format(self.__origin, form_spec)
+
+    def __del__(self):
+        if self.__delete_when_gc:
+            self.__origin.unlink(missing_ok=True)
+
+
+def get_temp_file(delete_when_gc: bool = True) -> Path:
+    tmp_name = os.path.join(tempfile.gettempdir(), os.urandom(24).hex())
+    path = Path(tmp_name)
+    if path.exists():
+        return get_temp_file()
+    else:
+        path.touch()
+        return _PathWrapper(path, delete_when_gc)

--- a/tests/test_tools/test_file_utils.py
+++ b/tests/test_tools/test_file_utils.py
@@ -1,6 +1,10 @@
 from pathlib import Path
+import sys
 
 
-def get_test_file(file_path:str, test_root_dir:str = 'tests') -> Path:
-    project_root = Path.cwd()
-    return Path(project_root, test_root_dir, file_path)
+def get_test_file(file_path: str) -> Path:
+    for sys_path in sys.path:
+        target_file = Path(sys_path, file_path)
+        if target_file.exists():
+            return target_file
+    raise FileNotFoundError()

--- a/tests/test_tools/test_file_utils.py
+++ b/tests/test_tools/test_file_utils.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def get_test_file(file_path:str, test_root_dir:str = 'tests') -> Path:
+    project_root = Path.cwd()
+    return Path(project_root, test_root_dir, file_path)


### PR DESCRIPTION
テストデータの読み書きのリファクタリングを行いました。

レビュー観点（for山田さん）

- すいませんが、本ブランチをチェックアウトいただいてWindowsのDockerコンテナのプロジェクトルート(/opt/jasmine)をルートにして全件テスト動く事と、PyCharm上で全件テスト通ること確認いただけますか？

レビュー観点（for大澤さん）

- IO stream使うかどうか検討したのですが、filenameを引数に動いてるので、修正は止めておきました。インタフェース的にも利用者としては、ファイル名渡すのは直感的ではあると思うので...
- ~~テストデータの書き込みについてはtempfileを使うようにしました。テスト終了時に自動的に消えるようにしました。その他余計な事前準備も不用になります~~
- tempfileは、作成と同時にファイルをオープンしてしまうのでテストに利用するには不適切でした。テスト前に明示的にcloseしてテストに流しても今度は自動でファイルが消えなくなるので、独自の処理でGC時にファイル削除するようにしました